### PR TITLE
Freedom E300

### DIFF
--- a/Adafruit_BluefruitLE_SPI.cpp
+++ b/Adafruit_BluefruitLE_SPI.cpp
@@ -57,6 +57,7 @@ SPISettings bluefruitSPI(4000000, MSBFIRST, SPI_MODE0);
     @param[in]  rstPin
 */
 /******************************************************************************/
+#define EOF (-1)
 Adafruit_BluefruitLE_SPI::Adafruit_BluefruitLE_SPI(int8_t csPin, int8_t irqPin, int8_t rstPin) :
     m_rx_fifo(m_rx_buffer, sizeof(m_rx_buffer), 1, true)
 {

--- a/Adafruit_BluefruitLE_UART.h
+++ b/Adafruit_BluefruitLE_UART.h
@@ -40,7 +40,7 @@
 #include "Arduino.h"
 #include <Adafruit_BLE.h>
 
-#define SOFTWARE_SERIAL_AVAILABLE   ( ! (defined (_VARIANT_ARDUINO_DUE_X_) || defined (_VARIANT_ARDUINO_ZERO_) || defined (ARDUINO_STM32_FEATHER)) )
+#define SOFTWARE_SERIAL_AVAILABLE   ( ! (defined (_VARIANT_ARDUINO_DUE_X_) || defined (_VARIANT_ARDUINO_ZERO_) || defined (ARDUINO_STM32_FEATHER) || defined (_VARIANT_FREEDOM_E300_)))
 
 #if SOFTWARE_SERIAL_AVAILABLE
   #include <SoftwareSerial.h>

--- a/examples/controller/controller.ino
+++ b/examples/controller/controller.ino
@@ -192,6 +192,11 @@ void loop(void)
     Serial.print(green, HEX);
     if (blue < 0x10) Serial.print("0");
     Serial.println(blue, HEX);
+
+    analogWrite(3, 255-green);
+    analogWrite(5, 255-blue);
+    analogWrite(6, 255-red);
+    
   }
 
   // Buttons

--- a/examples/controller/controller.ino
+++ b/examples/controller/controller.ino
@@ -15,7 +15,7 @@
 #include <string.h>
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_)
+#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_) && not defined (_VARIANT_FREEDOM_E300_)
   #include <SoftwareSerial.h>
 #endif
 

--- a/examples/controller/packetParser.cpp
+++ b/examples/controller/packetParser.cpp
@@ -1,7 +1,7 @@
 #include <string.h>
 #include <Arduino.h>
 #include <SPI.h>
-#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_)
+#if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_) && not defined (_VARIANT_FREEDOM_E300_)
   #include <SoftwareSerial.h>
 #endif
 


### PR DESCRIPTION
This code adds the _VARIANT_FREEDOM_E300_ ifdef to enable proper operation on Freedom E300 platforms. 

This code has only been tested with the "Controller" example

Run the "Controller" Example. We've tested this on the HiFive1 board to enable changing the RGB LED with the Color Picker part of the iPhone App.


